### PR TITLE
[FIX]: 지역 이탈시 이탈거리에 소수점 표현으로 최종 가격에 소수점 부여되는 부분 수정

### DIFF
--- a/src/services/historyService.js
+++ b/src/services/historyService.js
@@ -115,7 +115,7 @@ exports.isInAllowedArea = async (areaId,geoJSON)=>{
       toReturn.value = true
     } else {
       toReturn.value = false
-      toReturn.distance = result[0].distance
+      toReturn.distance = Math.floor(result[0].distance)
     }
 
     return toReturn;


### PR DESCRIPTION
## 작업사항

1. 지역 이탈시 이탈거리에 소수점 표현으로 최종 가격에 소수점 부여되는 부분 수정

## 관계된 이슈, PR 

#8 